### PR TITLE
Fix the db migration

### DIFF
--- a/src/Database.php
+++ b/src/Database.php
@@ -18,7 +18,7 @@ class Database {
      *
      * @var int
      */
-    protected $db_version = 2;
+    protected $db_version = 3;
 
     /**
      * Checks if the database schema requires updating, then updates it if necessary.
@@ -38,55 +38,25 @@ class Database {
      * @return void
      */
     function migrate_db($curr_version) {
-        // According to a comment on the dbDelta docs, you should always use
-        // CREATE, there's no need to UPDATE tables. Testing bears this out.
-        // https://developer.wordpress.org/reference/functions/dbdelta/#comment-4925
-        if ($curr_version < 1) {
-            $sql = $this->migrate_db_1();
-        } else if ($curr_version < 2) {
-            $sql = $this->migrate_db_2();
-        }
-	    require_once(ABSPATH . 'wp-admin/includes/upgrade.php');
-	    dbDelta($sql);
+        global $wpdb;
+
+        $table_name = $wpdb->prefix . 'split_tests';
+        $charset_collate = $wpdb->get_charset_collate();
+
+        // See also: https://developer.wordpress.org/plugins/creating-tables-with-plugins/#creating-or-updating-the-table
+        $sql = "CREATE TABLE $table_name (
+            split_test_id int(20) UNSIGNED NOT NULL,
+            test_type varchar(255) NOT NULL,
+            variant_index int(4) UNSIGNED NOT NULL,
+            test_or_convert enum('test', 'convert'),
+            granularity varchar(255) DEFAULT 'raw',
+            count int(11) UNSIGNED NOT NULL DEFAULT 1,
+            created_time datetime DEFAULT '0000-00-00 00:00:00' NOT NULL,
+            KEY split_test_idx (split_test_id, test_type, variant_index)
+        ) $charset_collate;";
+
+        require_once(ABSPATH . 'wp-admin/includes/upgrade.php');
+        dbDelta($sql);
         update_option('split_tests_db_version', $this->db_version);
-    }
-
-    /**
-     * Database migration 1 creates a basic split_tests db table.
-     *
-     * @return void
-     */
-    function migrate_db_1() {
-        global $wpdb;
-        $table_name = $wpdb->prefix . 'split_tests';
-        $charset_collate = $wpdb->get_charset_collate();
-        return "CREATE TABLE $table_name (
-            split_test_id BIGINT(20) UNSIGNED NOT NULL,
-            test_type VARCHAR(255) NOT NULL,
-            variant_index TINYINT UNSIGNED NOT NULL,
-            test_or_convert ENUM('test', 'convert'),
-            created_time DATETIME DEFAULT '0000-00-00 00:00:00' NOT NULL
-        ) $charset_collate;";
-    }
-
-    /**
-     * Database migration 2 adds two columns to the split_tests table:
-     * granularity (default 'raw') and count (default 1).
-     *
-     * @return void
-     */
-    function migrate_db_2() {
-        global $wpdb;
-        $table_name = $wpdb->prefix . 'split_tests';
-        $charset_collate = $wpdb->get_charset_collate();
-        return "CREATE TABLE $table_name (
-            split_test_id BIGINT(20) UNSIGNED NOT NULL,
-            test_type VARCHAR(255) NOT NULL,
-            variant_index TINYINT UNSIGNED NOT NULL,
-            test_or_convert ENUM('test', 'convert'),
-            granularity VARCHAR(255) DEFAULT 'raw',
-            count INT(8) UNSIGNED NOT NULL DEFAULT 1,
-            created_time DATETIME DEFAULT '0000-00-00 00:00:00' NOT NULL
-        ) $charset_collate;";
     }
 }

--- a/src/Database.php
+++ b/src/Database.php
@@ -28,16 +28,16 @@ class Database {
     function __construct() {
         $curr_db_version = get_option('split_tests_db_version', 0);
         if ($curr_db_version < $this->db_version) {
-            $this->migrate_db($curr_db_version);
+            $this->migrate_db();
         }
     }
 
     /**
-     * Migrates the database schema based on a version number.
+     * Migrates the database table schema using dbDelta.
      *
      * @return void
      */
-    function migrate_db($curr_version) {
+    function migrate_db() {
         global $wpdb;
 
         $table_name = $wpdb->prefix . 'split_tests';


### PR DESCRIPTION
Adds an index, `split_test_idx`, which it turns out is required by `dbDelta`. It turns out we don't really need to store each SQL migration with `dbDelta` so those are removed.