### PR TITLE
Fix title conversions

### DIFF
--- a/src/Assets.php
+++ b/src/Assets.php
@@ -70,7 +70,10 @@ class Assets {
                 'endpoint_url' => $endpoint_url,
                 'nonce' => wp_create_nonce('split_tests_event'),
                 'onload' => $this->plugin->onload_events,
-                'dom' => $this->plugin->dom_tests->get_variants()
+                'tests' => [
+                    ... $this->plugin->dom_tests->get_tests(),
+                    ... $this->plugin->title_tests->get_tests(),
+                ],
             ]
         ];
     }

--- a/src/Assets.php
+++ b/src/Assets.php
@@ -69,11 +69,11 @@ class Assets {
             'localize' => [
                 'endpoint_url' => $endpoint_url,
                 'nonce' => wp_create_nonce('split_tests_event'),
-                'onload' => $this->plugin->onload_events,
                 'tests' => [
                     ... $this->plugin->dom_tests->get_tests(),
                     ... $this->plugin->title_tests->get_tests(),
                 ],
+                'onload' => $this->plugin->onload_events,
             ]
         ];
     }

--- a/src/DomTests.php
+++ b/src/DomTests.php
@@ -29,24 +29,24 @@ class DomTests {
     }
 
     /**
-     * Query for DOM variants and select one per test.
+     * Return any active DOM tests.
      *
      * @return array
      */
-    function get_variants() {
-        $tests = get_posts([
+    function get_tests() {
+        $posts = get_posts([
             'post_type' => 'split_test',
             'meta_key' => 'test_type',
             'meta_value' => 'dom'
         ]);
-        $variants = [];
-        foreach ($tests as $post) {
-            $variant = $this->choose_variant($post);
-            if (!empty($variant)) {
-                $variants[$post->ID] = $variant;
+        $tests = [];
+        foreach ($posts as $post) {
+            $test = $this->choose_variant($post);
+            if (!empty($test)) {
+                $tests[] = $test;
             }
         }
-        return $variants;
+        return $tests;
     }
 
     /**
@@ -73,17 +73,16 @@ class DomTests {
             ],
             ... $_variants
         ];
+
+        // Pick a variant at random
         $index = rand(0, count($variants) - 1);
-        $variant = $variants[$index];
-
-        // Don't include the internal 'name' value.
-        unset($variant['name']);
-
-        // Add the index number
-        $variant['index'] = $index;
-
-        // Add the conversion type
-        $variant['conversion'] = get_field('conversion', $post->ID);
+        unset($variants[$index]['name']); // Don't include the internal 'name' value.
+        $variant = [
+            'id' => $post->ID,
+            'variant' => $index,
+            'conversion' => get_field('conversion', $post->ID),
+            ... $variants[$index]
+        ];
 
         // Add click conversion details
         if ($variant['conversion'] == 'click') {
@@ -107,7 +106,8 @@ class DomTests {
         }
 
         foreach ($_variants as $index => $variant) {
-            $_variants[$index]['description'] = count($variant['content']) . ' content changes';
+            $count = empty($variant['content']) ? 0 : count($variant['content']);
+            $_variants[$index]['description'] = "$count content changes";
         }
 
         $variants = [

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -88,7 +88,7 @@ class Plugin {
      * @return bool
      */
     function check_context($test_id) {
-        if (get_post_status($test_id) != 'publish') {
+        if (! $test_id || get_post_status($test_id) != 'publish') {
             return false;
         }
         $context = get_field('test_context', $test_id);
@@ -126,25 +126,12 @@ class Plugin {
     }
 
     /**
-     * Set up a front-end REST API increment call.
+     * Appends an onload event that will be sent upon the page loading.
      *
      * @return void
      */
-    function increment($test_or_convert, $split_test_id, $variant_index) {
-        $this->onload_events[] = [$test_or_convert, $split_test_id, $variant_index];
-    }
-
-    /**
-     * Redirect browser to a URL onload.
-     *
-     * @return void
-     */
-    function redirect($url) {
-        if (apply_filters('split_tests_is_headless', false)) {
-            $this->onload_events[] = ['redirect', $url];
-        } else {
-            wp_redirect($url);
-        }
+    function add_onload_event() {
+        $this->onload_events[] = func_get_args();
     }
 
     /**

--- a/src/TitleTests.php
+++ b/src/TitleTests.php
@@ -211,12 +211,16 @@ class TitleTests {
         ];
         $index = rand(0, count($variants) - 1);
         $variant = $variants[$index];
+        $variant['index'] = $index;
 
         // Cache this variant choice.
         $this->chosen_variants[$post->ID] = $variant;
 
-        // Increment the 'test' variable for this variant.
-        $this->increment_test_count($post->ID, $index);
+        // Increment the 'test' variable for this variant. (Unless it's a click
+        // conversion, those will get incremented automatically.)
+        if (get_field('conversion', $test_id) != 'click') {
+            $this->increment_test_count($post->ID, $index);
+        }
 
         return $variant;
     }
@@ -231,12 +235,35 @@ class TitleTests {
             return false;
         }
 
-        $conversion = get_field('conversion', $test_id);
-        if ($conversion == 'click') {
+        if (get_field('conversion', $test_id) == 'click') {
             return false;
         }
 
         return true;
+    }
+
+    /**
+     * Returns any active title tests.
+     *
+     * @return array
+     */
+    function get_tests() {
+        $tests = [];
+        foreach ($this->chosen_variants as $post_id => $variant) {
+            $test_id = get_post_meta($post_id, 'split_test_post_id', true);
+            $conversion = get_field('conversion', $test_id);
+            if ($conversion == 'click') {
+                $tests[] = [
+                    'id' => $test_id,
+                    'variant' => $variant['index'],
+                    'conversion' => 'click',
+                    'noop' => true,
+                    'click_content' => get_field('click_content', $test_id),
+                    'click_selector' => get_field('click_selector', $test_id),
+                ];
+            }
+        }
+        return $tests;
     }
 
     /**

--- a/src/TitleTests.php
+++ b/src/TitleTests.php
@@ -177,7 +177,7 @@ class TitleTests {
                     if ($variant_index > 0) {
                         $this->redirect_to_default($post->ID);
                     }
-                } else if (! empty($variants) && count($variants) > 0) {
+                } else if ($this->did_convert($variants, $split_test_post_id)) {
                     $this->increment_convert_count($post->ID, $variant_index);
                 }
             }
@@ -219,6 +219,24 @@ class TitleTests {
         $this->increment_test_count($post->ID, $index);
 
         return $variant;
+    }
+
+    /**
+     * Returns true of the conditions have been met to convert a title test.
+     *
+     * @return bool
+     */
+    function did_convert($variants, $test_id) {
+        if (empty($variants) || count($variants) == 0) {
+            return false;
+        }
+
+        $conversion = get_field('conversion', $test_id);
+        if ($conversion == 'click') {
+            return false;
+        }
+
+        return true;
     }
 
     /**

--- a/src/split-tests.js
+++ b/src/split-tests.js
@@ -40,8 +40,8 @@ export default function split_tests_init() {
     if (split_tests.onload) {
         let redirect = split_tests.onload.filter(event => event[0] == 'redirect');
         if (redirect.length > 0) {
-            // This is here to redirect unpublished post title tests back to
-            // the default permalink.
+            // This is here to redirect unpublished title tests back to the
+            // default permalink.
             window.location = redirect[0][1];
             return;
         } else {
@@ -49,13 +49,12 @@ export default function split_tests_init() {
         }
     }
 
-    if (split_tests.dom) {
-        for (let id in split_tests.dom) {
-            const variant = split_tests.dom[id];
-            postEvents([["test", parseInt(id), variant.index]]);
+    if (split_tests.tests) {
+        for (let test of split_tests.tests) {
+            postEvents([["test", parseInt(test.id), test.variant]]);
 
-            if (variant.content) {
-                for (let replacement of variant.content) {
+            if (test.content) {
+                for (let replacement of test.content) {
                     let targets = document.querySelectorAll(replacement.selector);
                     for (let target of targets) {
                         if (replacement.search && target.innerText.trim() != replacement.search.trim()) {
@@ -66,9 +65,9 @@ export default function split_tests_init() {
                 }
             }
 
-            if (variant.conversion == 'click') {
-                const selector = variant.click_selector;
-                const content = variant.click_content;
+            if (test.conversion == 'click') {
+                const selector = test.click_selector;
+                const content = test.click_content;
                 const targets = document.querySelectorAll(selector);
                 for (let target of targets) {
                     if (content && target.innerText.trim() != content.trim()) {
@@ -76,7 +75,7 @@ export default function split_tests_init() {
                     }
                     target.addEventListener('click', async e => {
                         e.preventDefault();
-                        await postEvents([["convert", parseInt(id), variant.index]]);
+                        await postEvents([["convert", parseInt(id), test.variant]]);
                         let href = findHref(e.target);
                         if (href) {
                             window.location = href;

--- a/src/split-tests.js
+++ b/src/split-tests.js
@@ -51,7 +51,8 @@ export default function split_tests_init() {
 
     if (split_tests.tests) {
         for (let test of split_tests.tests) {
-            postEvents([["test", parseInt(test.id), test.variant]]);
+
+            postEvents([['test', parseInt(test.id), test.variant]]);
 
             if (test.content) {
                 for (let replacement of test.content) {
@@ -75,7 +76,7 @@ export default function split_tests_init() {
                     }
                     target.addEventListener('click', async e => {
                         e.preventDefault();
-                        await postEvents([["convert", parseInt(id), test.variant]]);
+                        await postEvents([["convert", parseInt(test.id), test.variant]]);
                         let href = findHref(e.target);
                         if (href) {
                             window.location = href;


### PR DESCRIPTION
The status quo is that title tests are all messed—when they're configured to only convert on "homepage click" they are still getting conversion numbers added on pageload. This PR fixes the problem and cleans up some of the structures that made it hard to see the problem in the first place.