### PR TITLE
DOM test CSS changes

### DIFF
--- a/acf-fields/split-test-post.json
+++ b/acf-fields/split-test-post.json
@@ -180,6 +180,7 @@
                     "collapsed": "",
                     "button_label": "Add Replacement",
                     "rows_per_page": 20,
+                    "parent_repeater": "field_66982f55bb940",
                     "sub_fields": [
                         {
                             "key": "field_66982648ec8a2",
@@ -244,8 +245,7 @@
                             "append": "",
                             "parent_repeater": "field_66982606ec8a1"
                         }
-                    ],
-                    "parent_repeater": "field_66982f55bb940"
+                    ]
                 },
                 {
                     "key": "field_6740b0595dbdb",
@@ -268,6 +268,7 @@
                     "collapsed": "",
                     "button_label": "Add Change",
                     "rows_per_page": 20,
+                    "parent_repeater": "field_66982f55bb940",
                     "sub_fields": [
                         {
                             "key": "field_6740b0795dbdc",
@@ -340,7 +341,28 @@
                             "append": "",
                             "parent_repeater": "field_6740b0595dbdb"
                         }
-                    ],
+                    ]
+                },
+                {
+                    "key": "field_6746107fb3d99",
+                    "label": "Add CSS",
+                    "name": "css",
+                    "aria-label": "",
+                    "type": "textarea",
+                    "instructions": "",
+                    "required": 0,
+                    "conditional_logic": 0,
+                    "wrapper": {
+                        "width": "",
+                        "class": "",
+                        "id": ""
+                    },
+                    "default_value": "",
+                    "maxlength": "",
+                    "allow_in_bindings": 0,
+                    "rows": 5,
+                    "placeholder": "",
+                    "new_lines": "",
                     "parent_repeater": "field_66982f55bb940"
                 }
             ]
@@ -360,13 +382,15 @@
                 "id": ""
             },
             "choices": {
+                "click": "Click",
                 "page-load": "Page Load",
-                "click": "Click"
+                "scroll": "Scroll"
             },
             "default_value": false,
             "return_format": "value",
             "multiple": 0,
             "allow_null": 0,
+            "allow_in_bindings": 1,
             "ui": 0,
             "ajax": 0,
             "placeholder": ""

--- a/src/Assets.php
+++ b/src/Assets.php
@@ -31,6 +31,9 @@ class Assets {
         // Enqueue front-end JS
         add_action('wp_enqueue_scripts', [$this, 'wp_enqueue_scripts']);
 
+        // Output any active DOM test CSS
+        add_action('wp_print_scripts', [$this, 'wp_print_scripts']);
+
         // Enqueue admin assets
         add_action('admin_enqueue_scripts', [$this, 'admin_enqueue_scripts']);
     }
@@ -54,6 +57,21 @@ class Assets {
     }
 
     /**
+     * Add CSS style when the scripts are getting output.
+     *
+     * @return void
+     */
+    function wp_print_scripts() {
+        if (is_admin()) {
+            return;
+        }
+        $css = $this->plugin->dom_tests->get_css();
+        if (!empty($css)) {
+            echo "<style>\n$css</style>\n";
+        }
+    }
+
+    /**
      * Return JavaScript details for the front-end.
      *
      * @return array
@@ -74,6 +92,7 @@ class Assets {
                     ... $this->plugin->title_tests->get_tests(),
                 ],
                 'onload' => $this->plugin->onload_events,
+                'css' => $this->plugin->dom_tests->get_css(),
             ]
         ];
     }

--- a/src/DomTests.php
+++ b/src/DomTests.php
@@ -50,6 +50,22 @@ class DomTests {
     }
 
     /**
+     * Return CSS changes from any active DOM tests.
+     *
+     * @return string
+     */
+    function get_css() {
+        $tests = $this->get_tests();
+        $css = '';
+        foreach ($tests as $test) {
+            if (!empty($test['css'])) {
+                $css .= $test['css'] . "\n";
+            }
+        }
+        return $css;
+    }
+
+    /**
      * Select a variant from a split_test post.
      *
      * @return array | null
@@ -114,6 +130,14 @@ class DomTests {
             $separator = empty($description) ? '' : ', ';
             $plural = (! empty($variant['classes']) && count($variant['classes']) > 1) ? 's' : '';
             $description .= empty($variant['classes']) ? '' : $separator . count($variant['classes']) . ' class change' . $plural;
+
+            // Describe CSS changes
+            if (!empty($variant['css'])) {
+                if (!empty($description)) {
+                    $description .= ', ';
+                }
+                $description .= 'CSS changes';
+            }
 
             $_variants[$index]['description'] = $description;
         }

--- a/src/split-tests.js
+++ b/src/split-tests.js
@@ -89,7 +89,7 @@ export default function split_tests_init() {
                     }
                     target.addEventListener('click', async e => {
                         e.preventDefault();
-                        await postEvents([["convert", parseInt(test.id), test.variant]]);
+                        await postEvents([['convert', parseInt(test.id), test.variant]]);
                         let href = findHref(e.target);
                         if (href) {
                             window.location = href;
@@ -99,6 +99,27 @@ export default function split_tests_init() {
                     });
                 }
             }
+
+            if (test.conversion == 'scroll') {
+                if (!split_tests.onscroll) {
+                    split_tests.onscroll = [];
+                }
+                split_tests.onscroll.push(test);
+            }
+        }
+
+        if (split_tests.onscroll) {
+            let converted = false;
+            window.addEventListener('scroll', async () => {
+                if (!converted && window.scrollY > window.innerHeight) {
+                    converted = true;
+                    let events = [];
+                    for (let test of split_tests.onscroll) {
+                        events.push(['convert', parseInt(test.id), test.variant]);
+                    }
+                    await postEvents(events);
+                }
+            });
         }
     }
 }

--- a/src/split-tests.js
+++ b/src/split-tests.js
@@ -112,8 +112,11 @@ export default function split_tests_init() {
             let converted = false;
             const scrollStart = window.scrollY;
             window.addEventListener('scroll', async () => {
-                if (!converted && window.scrollY > (startScroll - window.innerHeight))
-                if (!converted && window.scrollY > window.innerHeight) {
+                if (converted) {
+                    return;
+                }
+                const scrollDistance = Math.abs(window.scrollY - scrollStart);
+                if (scrollDistance > window.innerHeight) {
                     converted = true;
                     let events = [];
                     for (let test of split_tests.onscroll) {

--- a/src/split-tests.js
+++ b/src/split-tests.js
@@ -110,7 +110,9 @@ export default function split_tests_init() {
 
         if (split_tests.onscroll) {
             let converted = false;
+            const scrollStart = window.scrollY;
             window.addEventListener('scroll', async () => {
+                if (!converted && window.scrollY > (startScroll - window.innerHeight))
                 if (!converted && window.scrollY > window.innerHeight) {
                     converted = true;
                     let events = [];


### PR DESCRIPTION
The ability for DOM tests to add/remove classes has a drawback for test near the top of the page that show a flash of unstyled content. This PR adds a freeform CSS change for test variants that drops an inline `<style>` tag onto the page.

<img width="967" alt="Screenshot 2024-11-26 at 2 39 26 PM" src="https://github.com/user-attachments/assets/4c1a038e-c5c5-4e64-9372-78c09f2376f1">

This PR also adds a new conversion criterion: scrolling. If you scroll down 1vh it makes the test convert.